### PR TITLE
新規ルートパターン画面(静的)の作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
+import './new/index.dart';
 
-void main() => runApp(MainScreen());
+void main() {
+  runApp(new MaterialApp(
+    title: "Test",
+    routes: <String, WidgetBuilder>{
+      '/': (BuildContext context) => new MainScreen(),
+      '/new': (BuildContext context) => new NewRootScreen(),
+    },
+  ));
+}
 
 class MainScreen extends StatelessWidget {
   Widget build(BuildContext context) {
@@ -11,12 +20,20 @@ class MainScreen extends StatelessWidget {
       ),
       home: Scaffold(
         appBar: AppBar(
-          title: Text('ワンタップ経路表示')
+          title: Text('ワンタップ経路表示'),
+          actions: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.add_circle),
+              onPressed: () {
+                Navigator.pushNamed(context, '/new');
+              },
+            ),
+          ],
         ),
         body: Center(
           child: RoutePatten(),
         ),
-      )
+      ),
     );
   }
 }
@@ -62,7 +79,7 @@ class _RoutePatten extends State<RoutePatten> {
           ),
         ),
         // 経路表示ボタン
-        routeButton,
+        routeButton
       ],
     );
   }

--- a/lib/new/index.dart
+++ b/lib/new/index.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+// 新規ルートパターン作成画面
+class NewRootScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('ルートパターン作成'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            StationInput(station: "最寄駅"),
+            StationInput(station: "終着駅"),
+            RequiredTimeInput(),
+            CategoryInput(),
+            CreateButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 最寄駅、終着駅の入力共通フォーム
+class StationInput extends StatelessWidget {
+  final String station;
+  StationInput({this.station});
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(20),
+      child: TextField(
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: station,
+          hintText: "ここに登録したい${station}を入力してね"
+        ),
+      ),
+    );
+  }
+}
+
+// 最寄駅までの所要時間入力フォーム
+class RequiredTimeInput extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(20),
+      child: TextField(
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: "最寄駅までの所要時間",
+          hintText: "例：20"
+        ),
+      ),
+    );
+  }
+}
+
+// カテゴリー入力フォーム
+class CategoryInput extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(20),
+      child: TextField(
+        decoration: InputDecoration(
+          border: OutlineInputBorder(),
+          labelText: "カテゴリー",
+          hintText: "カテゴリー名を入力してね"
+        ),
+      ),
+    );
+  }
+}
+
+// 登録ボタン
+class CreateButton extends StatelessWidget {
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(20),
+      child: RaisedButton(
+        child: Text("登録"),
+        onPressed: () {
+
+        },
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:ramirez/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(MainScreen());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
新規ルートパターンを追加する画面を作成

- [x] 新規ルートパターン画面へのリンクを作成
先にルートを定義していおく必要があった
- [x] 最寄駅を入力するフォームの作成
- [x] 終着駅を入力するフォームの作成
- [x] 最寄駅までの所要時間を入力するフォームの作成
- [x] パターン名を入力するフォームの作成
- [x] 登録ボタンの作成